### PR TITLE
Fix security vulnerability CVE-2023-0842

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack module to load XML files.",
   "main": "index.js",
   "dependencies": {
-    "xml2js": "^0.4.16",
+    "xml2js": "^0.5.0",
     "loader-utils": "^1.0.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
Information about a [security vulnerability](https://github.com/advisories/GHSA-776f-qx25-q3cc) was published recently regarding older versions of [`xml2js`](https://github.com/Leonidas-from-XIV/node-xml2js) (specifically, versions < 0.5.0)

The GitHub advisory ranks this as a high severity vulnerability.

This PR updates the version of `xml2js` used by `xml-loader` to version `0.5.0`.